### PR TITLE
Added data-trunk link to rust to get demo to serve

### DIFF
--- a/RustFrontEnd/index.html
+++ b/RustFrontEnd/index.html
@@ -4,5 +4,6 @@
     <meta charset="utf-8" />
     <title>Yew App</title>
     <link data-trunk rel="css" href="style.css" />
+    <link data-trunk rel="rust" />
 </head>
 </html>


### PR DESCRIPTION
Tried the tutorial on front end rust (It was fun!) 

Ran into an issue running trunk serve.

```
$ trunk serve
2025-08-03T20:22:13.819582Z  INFO 🚀 Starting trunk 0.21.14
2025-08-03T20:22:13.900954Z  INFO 📦 starting build
   Compiling rust-frontend-test v0.1.0 (/home/haydon/workspace/rust-frontend-test)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
2025-08-03T20:22:14.447190Z ERROR ❌ error
error from build pipeline

Caused by:
    0: HTML build pipeline failed (1 errors), showing first
    1: failed to finalize asset pipeline
    2: Document has neither a <link data-trunk rel="rust"/> nor a <body>. Either one must be present.
2025-08-03T20:22:14.447241Z  INFO 📡 serving static assets at -> /
2025-08-03T20:22:14.447542Z  INFO 📡 server listening at:
2025-08-03T20:22:14.447552Z  INFO     🏠 http://127.0.0.1:8080/
2025-08-03T20:22:14.447555Z  INFO     🏠 http://[::1]:8080/
2025-08-03T20:22:14.447617Z  INFO     🏠 http://localhost.:8080/
```

Looks like trunk now needs a link to rust as well.  

Keep up the great work!